### PR TITLE
Improve readability and link consistency in CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,11 +3,21 @@
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+community a harassment-free experience for everyone, regardless of:
+- Age
+- Body size
+- Visible or invisible disability
+- Ethnicity
+- Sex characteristics
+- Gender identity and expression
+- Level of experience
+- Education
+- Socio-economic status
+- Nationality
+- Personal appearance
+- Race
+- Religion
+- Sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -114,14 +124,12 @@ the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
 
-[homepage]: https://www.contributor-covenant.org
+
 
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at


### PR DESCRIPTION
This PR improves the **CODE_OF_CONDUCT.md** by enhancing readability and standardizing link formatting:

- **Reformatted** the list of protected characteristics in "Our Pledge" into bullet points for better scanability.
- **Simplified** the "Attribution" section by replacing the redundant reference link with a single inline link for the Contributor Covenant, aligning it with the Mozilla link style.

Changes:
- Converted a long sentence to a bulleted list in "Our Pledge".
- Removed [homepage] reference and second inline link in "Attribution".
- Ensured consistent and user-friendly formatting.

No functional changes,purely a documentation improvement.